### PR TITLE
Adjust afvalophaalgebieden swagger link to use new path

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -130,7 +130,7 @@
             <tr>
                 <td>Afvalregels bij locatie x, y</td>
                 <td><a href="/afvalophaalgebieden/search/">Online API</a></td>
-                <td><a href="/api/swagger/?url=/afvalophaalgebieden/afvalophaalgebieden/spec.json">OpenAPI Documentatie</a></td>
+                <td><a href="/api/swagger/?url=/afvalophaalgebieden/openapi.yaml">OpenAPI Documentatie</a></td>
                 <td>Live</td>
                 <td><a rel="license" href="https://creativecommons.org/publicdomain/zero/1.0/"><img
                     src="https://i.creativecommons.org/p/zero/1.0/88x31.png" width="88" height="31" alt="CC0"/></a></td>


### PR DESCRIPTION
This solves the issue that the live test-it-out did not work

Prerequisite: Have the PR in afvalophaalgebieden approved and merged so that the swagger url works