### PR TITLE
SIG-875 Link to correct Swagger file for SIA

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -266,7 +266,7 @@
           <tr>
             <td>Meldingen / Signalen</td>
             <td><a href="/signals">Online API</a></td>
-            <td><a href="/signals/redoc/">OpenAPI</a></td>
+            <td><a href="/api/swagger/?url=/signals/swagger/openapi.yaml">OpenAPI</a></td>
             <td>Live</td>
             <td><a rel="license" href="https://creativecommons.org/publicdomain/zero/1.0/"><img
                                  src="https://i.creativecommons.org/p/zero/1.0/88x31.png" width="88" height="31" alt="CC0"/></a></td>


### PR DESCRIPTION
We replaced generated Swagger doc with handwritten OpenAPI 3 spec, the catalog should refer to it.