### PR TITLE
Fixing Handelsregister API Url

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -256,7 +256,7 @@
           <tr>
             <td>Handelsregister</td>
             <td><a href="/handelsregister">Online API</a></td>
-            <td><a href="/api/swagger/?url=/handelsregister/static/openapi.yml">OpenAPI</a></td>
+            <td><a href="/api/swagger/?url=/handelsregister/docs/api-docs/%3Fformat%3Dopenapi">OpenAPI</a></td>
             <td>Alleen bereikbaar binnen de gemeente</td>
             <td><a rel="license" href="https://creativecommons.org/publicdomain/zero/1.0/"><img
                                  src="https://i.creativecommons.org/p/zero/1.0/88x31.png" width="88" height="31" alt="CC0"/></a></td>


### PR DESCRIPTION
Replace static yml with auto generated docs.

Works on acceptance:
https://acc.api.data.amsterdam.nl/api/swagger/?url=/handelsregister/docs/api-docs/%3Fformat%3Dopenapi#/geosearch/geosearch_list