### PR TITLE
[DS-282] Add id attribute to H1 elements as anker

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -668,7 +668,7 @@
         </tbody>
     </table>
 
-    <h1 id="map-title-services">Map Tile Services</h1>
+    <h1 id="map-tile-services">Map Tile Services</h1>
     <p>Map Tile services conform de OGC richtlijnen (WMTS), te gebruiken met software voor ruimtelijke data, zoals <a href="http://www.qgis.org/" target="_blank" rel="noopener">QGIS</a>.
         Of de tiles zijn te gebruiken in webclients, zoals Leaflet en OpenLayers. Daarvoor zijn url's t1 t/m t4 beschikbaar voor browser multi-fetch.</p>
     <table class="table" cellspacing="0" cellpadding="0">

--- a/static/index.html
+++ b/static/index.html
@@ -136,7 +136,7 @@
         </a>
     </div>
 
-    <h1>RESTful API</h1>
+    <h1 id="restful-api">RESTful API</h1>
     <p>Dit overzicht van browsable interfaces en openAPI documentatie beperkt zich tot de API's
 	ontwikkeld door programma DataPunt van Onderzoek, Informatie en Statistiek.
 	API's van andere partijen vind je in de
@@ -394,7 +394,7 @@
         </tbody>
     </table>
 
-    <h1>Geo-webservices</h1>
+    <h1 id="geo-webservices">Geo-webservices</h1>
     <p>Geografische webservices conform de OGC richtlijnen (WMS en WFS).
         Deze zijn te gebruiken met webclients als Leaflet en Open Layers of met software voor ruimtelijke data, zoals <a href="http://www.qgis.org/" target="_blank" rel="noopener">QGIS</a>.<br></p>
     <table class="table" cellspacing="0" cellpadding="0">
@@ -668,7 +668,7 @@
         </tbody>
     </table>
 
-    <h1>Map Tile Services</h1>
+    <h1 id="map-title-services">Map Tile Services</h1>
     <p>Map Tile services conform de OGC richtlijnen (WMTS), te gebruiken met software voor ruimtelijke data, zoals <a href="http://www.qgis.org/" target="_blank" rel="noopener">QGIS</a>.
         Of de tiles zijn te gebruiken in webclients, zoals Leaflet en OpenLayers. Daarvoor zijn url's t1 t/m t4 beschikbaar voor browser multi-fetch.</p>
     <table class="table" cellspacing="0" cellpadding="0">


### PR DESCRIPTION
In order to refer the URL map.data.amsterdam.nl to api.data.amsterdam.nl/api#geo-webservices an ID attribute needed to be added to the H1 element. The value of the ID is kept inline with the H1 value names.

Resolves: [DS-282]