### PR TITLE
[DS-567] add name to logo for accessibility

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -111,7 +111,7 @@
 <body>
     <div class="header">
         <a href="https://data.amsterdam.nl/" title="Naar voorpagina Dataportaal">
-            <img class="header_logo" src="gemeente_Amsterdam_logo.svg" width="64" height="30" alt="Logo Gemeente Amsterdam">
+            <img class="header_logo" src="gemeente_Amsterdam_logo.svg" width="64" height="30" alt="Gemeente Amsterdam" name="Gemeente Amsterdam">
             <span class="header_title">Data en informatie</span>
         </a>
     </div>


### PR DESCRIPTION
Based on accessibility audit the logo as seen on api.data.amsterdam.nl/api is provided with name metadata. Also the alt is changed to "gemeente Amsterdam".