### PR TITLE
Use shared Swagger for DSO apis.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,5 @@ services:
       - "8080:80"
     environment:
       BASE_URL: "https://acc.api.data.amsterdam.nl/"
+    volumes:
+      - ./static/:/usr/share/nginx/html/

--- a/static/dso_tables.js
+++ b/static/dso_tables.js
@@ -51,7 +51,7 @@
                 "beschrijving":dataset.description,
                 "api_urls": {},
                 "documentatie_urls": {"ReadTheDocs": dataset.environments[0].documentation_url},
-                "specificatie_urls": {"Specificatie": dataset.environments[0].specification_url},
+                "specificatie_urls": {"Swagger": "/api/swagger/?url=" + dataset.environments[0].specification_url},
                 "beschikbaarheid": dataset.terms_of_use.government_only?"Beperkt toegankelijk":"Openbaar",
                 "licentie": "CC0"
             };


### PR DESCRIPTION
Use shared swagger until Azure migration is performed.