### PR TITLE
Update base image to 1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # webserver image.
-FROM nginx:1.19.2
+FROM nginx:1.21
 MAINTAINER datapunt.ois@amsterdam.nl
 
 ENV BASE_URL=https://api.data.amsterdam.nl/


### PR DESCRIPTION
Fixes the following:

- Debian Security Update for tiff (DSA 5108-1)
- Debian Security Update for zlib (DSA 5111-1)
- Debian Security Update for expat (DSA 5085-2)
- Debian Security Update for Open Secure Sockets Layer (OpenSSL) (DSA 5103-1)
- Debian Security Update for cyrus-sasl2 (DSA 5087-1)
- Debian Security Update for expat (DSA 5085-1)
- Debian Security Update for expat (DSA 5073-1)
- Debian Security Update for icu (DSA 5014-1)
- Debian Security Update for tiff (DSA 4997-1)
- Debian Security Update for Open Secure Sockets Layer (OpenSSL) (DSA 4963-1)
- Debian Security Update for krb5 (DSA 4944-1)
- Debian Security Update for systemd (DSA 4942-1)
- Debian Security Update for nettle (DSA 4933-1)
- Debian Security Update for libwebp (DSA 4930-1)
- Debian Security Update for lz4 (DSA 4919-1)
- Debian Security Update for libzstd (DSA 4859-1)
- Debian Security Update for libzstd (DSA 4850-1)
- Debian Security Update for libx11 (DSA 4920-1)
- Debian Security Update for tiff (DSA 4869-1)
- Debian Security Update for curl (DSA 4881-1)
- Debian Security Update for Open Secure Sockets Layer (OpenSSL) (DSA 4875-1)
- Debian Security Update for openldap (DSA 4860-1)
- Debian Security Update for openldap (DSA 4845-1)
- Debian Security Update for Open Secure Sockets Layer (OpenSSL) (DSA 4855-1)
- Debian Security Update for p11-kit (DSA 4822-1)
- Debian Security Update for apt (DSA 4808-1)
- Debian Security Update for Open Secure Sockets Layer (OpenSSL) (DSA 4807-1)
- Debian Security Update for krb5 (DSA 4795-1)
- Debian Security Update for openldap (DSA 4792-1)
- Debian Security Update for openldap (DSA 4782-1)
- Debian Security Update for freetype (DSA 4777-1)
- GNU Bash Privilege Escalation Vulnerability for Debian