### PR TITLE
Prevent that subdomains of api.data.amsterdam.nl get prefixed with acc

### DIFF
--- a/cmd.sh
+++ b/cmd.sh
@@ -11,7 +11,7 @@ then
     echo "Converting t1.data.amsterdam.nl to acc.t1.map.data.amsterdam.nl"
     sed -i -e"s;\(https://\)\(.*t1.data.amsterdam.nl\)\(.*\);\1acc.t1.data.amsterdam.nl\3;" /usr/share/nginx/html/index.html
     echo "Converting api.data.amsterdam.nl to acc.api.map.data.amsterdam.nl"
-    sed -i -e"s;\(https://\)\(.*api.data.amsterdam.nl\)\(.*\);\1acc.api.data.amsterdam.nl\3;" /usr/share/nginx/html/index.html
+    sed -i -e"s;\(https://\)\([^.]*api.data.amsterdam.nl\)\(.*\);\1acc.api.data.amsterdam.nl\3;" /usr/share/nginx/html/index.html
 fi
 
 echo "Converting %BASE_URL% to ${BASE_URL}"


### PR DESCRIPTION
The banner about the api keys has a link to
`keys.api.data.amsterdam.nl`, this link now gets `keys.` -> `acc.` substition that is unwanted, so the sed regex needed a small tweak.