### PR TITLE
Also list under_development datasets

### DIFF
--- a/static/dso_tables.js
+++ b/static/dso_tables.js
@@ -79,6 +79,9 @@ function parseDSOjson(json, table, api_name = "Rest API") {
     for (let name of Object.keys(json.datasets)) {
         let dataset = json.datasets[name]
         let stableVersions = dataset.versions.filter(ds => ds.status == "stabiel")
+        if (!stableVersions.length) {
+            stableVersions = dataset.versions.filter(ds => ds.status == "in ontwikkeling")
+        }
         if (stableVersions.length) {
             row = {
                 base_url: stableVersions[0][urlProp],


### PR DESCRIPTION
De benkagg table was niet zichtbaar op het overzicht op /api omdat die alleen een under_development versie heeft. Als er geen stable versie is kijken we nu ook naar under_development